### PR TITLE
fix(parens): paren-descriptions highlight properly

### DIFF
--- a/syntax/ohm.vim
+++ b/syntax/ohm.vim
@@ -9,7 +9,7 @@ highlight link GrammarName Keyword
 " Comments
 " ---------------------------------------------------------------------------
 syntax region Comment start='\V\/*' end='\V*\/'
-syntax region Comment start='\v(\a+\_s*)@<=\(' end='\v\)(\_s*\=)@='
+syntax match Comment '\v(\a+\_s*)@<=\([^)]*\)(\_s*\=)@='
 syntax match Comment '\v//.*'
 
 " ---------------------------------------------------------------------------


### PR DESCRIPTION
I switched back to syntax matches because syntax regions are too aggressive with
matching, and are often buggy. This requires paren-descriptions to be one line.

fixes #1
